### PR TITLE
Disable Ktlint import-ordering

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+charset = utf-8
+end_of_line = crlf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Disable Ktlint import ordering temporarily because of AndroidStudio Kotlin formatting bug. read more here:
+# https://youtrack.jetbrains.com/issue/KT-10974
+[*.{kt, kts}]
+disabled_rules = import-ordering

--- a/app/src/main/kotlin/com/mohsenoid/rickandmorty/injection/DependenciesProvider.kt
+++ b/app/src/main/kotlin/com/mohsenoid/rickandmorty/injection/DependenciesProvider.kt
@@ -47,7 +47,6 @@ import com.mohsenoid.rickandmorty.view.episode.list.EpisodeListContract
 import com.mohsenoid.rickandmorty.view.episode.list.EpisodeListFragment
 import com.mohsenoid.rickandmorty.view.episode.list.EpisodeListPresenter
 import com.mohsenoid.rickandmorty.view.episode.list.adapter.EpisodeListAdapter
-import java.net.UnknownHostException
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
@@ -55,6 +54,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.net.UnknownHostException
 
 class DependenciesProvider(private val context: Application) {
 

--- a/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/base/BaseActivity.kt
+++ b/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/base/BaseActivity.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.mohsenoid.rickandmorty.RickAndMortyApplication
 import com.mohsenoid.rickandmorty.injection.DependenciesProvider
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
 
 abstract class BaseActivity : AppCompatActivity(), CoroutineScope {
 

--- a/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/base/BaseFragment.kt
+++ b/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/base/BaseFragment.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import androidx.fragment.app.Fragment
 import com.mohsenoid.rickandmorty.RickAndMortyApplication
 import com.mohsenoid.rickandmorty.injection.DependenciesProvider
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
 
 abstract class BaseFragment : Fragment(), CoroutineScope {
 

--- a/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/character/list/CharacterListActivity.kt
+++ b/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/character/list/CharacterListActivity.kt
@@ -6,8 +6,8 @@ import android.os.Bundle
 import com.mohsenoid.rickandmorty.R
 import com.mohsenoid.rickandmorty.injection.DependenciesProvider
 import com.mohsenoid.rickandmorty.view.base.BaseActivity
-import java.util.ArrayList
 import timber.log.Timber
+import java.util.ArrayList
 
 class CharacterListActivity : BaseActivity() {
 

--- a/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/character/list/CharacterListFragment.kt
+++ b/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/character/list/CharacterListFragment.kt
@@ -13,9 +13,9 @@ import com.mohsenoid.rickandmorty.injection.DependenciesProvider
 import com.mohsenoid.rickandmorty.view.base.BaseFragment
 import com.mohsenoid.rickandmorty.view.character.details.CharacterDetailsActivity
 import com.mohsenoid.rickandmorty.view.character.list.adapter.CharacterListAdapter
-import java.util.ArrayList
 import kotlinx.android.synthetic.main.fragment_character_list.*
 import kotlinx.coroutines.launch
+import java.util.ArrayList
 
 class CharacterListFragment : BaseFragment(), CharacterListContract.View,
     CharacterListAdapter.ClickListener {

--- a/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/character/list/adapter/CharacterListAdapter.kt
+++ b/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/character/list/adapter/CharacterListAdapter.kt
@@ -6,8 +6,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.mohsenoid.rickandmorty.R
 import com.mohsenoid.rickandmorty.domain.entity.CharacterEntity
 import com.mohsenoid.rickandmorty.util.dispatcher.DispatcherProvider
-import java.util.ArrayList
 import kotlinx.android.synthetic.main.item_character.view.*
+import java.util.ArrayList
 
 class CharacterListAdapter(
     private val dispatcherProvider: DispatcherProvider,

--- a/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/character/list/adapter/CharacterViewHolder.kt
+++ b/app/src/main/kotlin/com/mohsenoid/rickandmorty/view/character/list/adapter/CharacterViewHolder.kt
@@ -6,11 +6,11 @@ import com.mohsenoid.rickandmorty.R
 import com.mohsenoid.rickandmorty.domain.entity.CharacterEntity
 import com.mohsenoid.rickandmorty.util.dispatcher.DispatcherProvider
 import com.squareup.picasso.Picasso
-import kotlin.coroutines.CoroutineContext
 import kotlinx.android.synthetic.main.item_character.view.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
 
 class CharacterViewHolder internal constructor(
     internal val view: View

--- a/app/src/test/kotlin/com/mohsenoid/rickandmorty/data/db/DbTest.kt
+++ b/app/src/test/kotlin/com/mohsenoid/rickandmorty/data/db/DbTest.kt
@@ -8,7 +8,6 @@ import com.mohsenoid.rickandmorty.data.mapper.CharacterDbMapper
 import com.mohsenoid.rickandmorty.test.CharacterDataFactory
 import com.mohsenoid.rickandmorty.test.DataFactory
 import com.mohsenoid.rickandmorty.test.EpisodeDataFactory
-import java.io.IOException
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
@@ -24,6 +23,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.io.IOException
 
 @Config(sdk = [Build.VERSION_CODES.P])
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/kotlin/com/mohsenoid/rickandmorty/view/character/list/CharacterListPresenterTest.kt
+++ b/app/src/test/kotlin/com/mohsenoid/rickandmorty/view/character/list/CharacterListPresenterTest.kt
@@ -11,7 +11,6 @@ import com.mohsenoid.rickandmorty.test.DataFactory.randomString
 import com.mohsenoid.rickandmorty.util.config.ConfigProvider
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.eq
-import java.util.ArrayList
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.Verify
 import org.amshove.kluent.VerifyNoFurtherInteractions
@@ -28,6 +27,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
+import java.util.ArrayList
 
 class CharacterListPresenterTest {
 


### PR DESCRIPTION
Disabled because of AndroidStudio Kotlin formatting conflicts with Ktlint.

More details here:
https://github.com/pinterest/ktlint/issues/527
https://youtrack.jetbrains.com/issue/KT-10974